### PR TITLE
🐞 Fix bug where new Guild Server doesn't store id

### DIFF
--- a/src/Actions/Guild.ts
+++ b/src/Actions/Guild.ts
@@ -16,7 +16,7 @@ const Log = Logger.getInstance();
 export async function addGuild(guild: Guild) {
   // Store Guild Entry
   return GuildModel.create({
-    guildID: guild.id,
+    guildID: guild.id.toString(),
     guildName: guild.name,
     responseChannel: null,
   })

--- a/src/Actions/Messages.ts
+++ b/src/Actions/Messages.ts
@@ -50,13 +50,11 @@ export async function handleGuildMessage(msg: DiscordenoMessage) {
         // Make sure Guild is stored in DB
         const guild_entry = await GuildModel.where('guildID', msg.guildId.toString()).get();
         if (!guild_entry.length) {
-          Log.Error('Guild ID not found: ', msg.guildId);
+          Log.Warning('Guild ID not found: ', msg.guildId);
           const guild = await getGuild(msg.guildId);
           GUILD_CACHE.set(msg.guildId.toString(), guild as any, GUILD_CACHE_TTL);
           await addGuild(guild as any);
           cached_guild = guild as any;
-
-
         } else {
           GUILD_CACHE.set(msg.guildId.toString(), (guild_entry as any)[0], GUILD_CACHE_TTL);
           cached_guild = (guild_entry as any)[0];
@@ -68,7 +66,7 @@ export async function handleGuildMessage(msg: DiscordenoMessage) {
   }
 
   // Handle message only in verified channels
-  if (isFromDirectMessage || cached_guild?.responseChannel === null || channel?.name === cached_guild?.responseChannel) {
+  if (isFromDirectMessage || (cached_guild?.responseChannel === null || cached_guild?.responseChannel === undefined) || channel?.name === cached_guild?.responseChannel) {
     // Extract/Confirm Valid Command
     if (content.startsWith('!')) {
       Log.Info(`${author.username} issued command: ${content}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 // Project Configuration
 const CONFIG = {
-  version: '1.6.3',
+  version: '1.6.4',
 }
 export default CONFIG;


### PR DESCRIPTION
### 🐞 Major Bug Fix
- Fix issue where the bot doesn't store correct id (*empty*) when invited to new Server, which causes the bot to not respond
- Fix issue where new joined Server doesn't Cache `responseChannel` as null, which was checked when responding

### 👔 Detailed Information
- GuildIds are stored a BigInt but as a String on the DB. This caused an issue, so fix converted BigInt to String